### PR TITLE
background-repeat: no repeat for landing page image

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -128,7 +128,8 @@
       height: 100vh;
       background-image: url("http://i65.tinypic.com/a5fgv6.jpg");
       background-attachment: fixed;
-      background-position: center; 
+      background-position: center;
+      background-repeat: no-repeat; 
     }
 
     .landing-tagline{


### PR DESCRIPTION
+ When viewing the site on a really big screen, should prevent tiling